### PR TITLE
Fix for the maven repository url in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <repository>
       <id>weswit</id>
       <name>Weswit repository</name>
-      <url>http://www.lightstreamer.com/repo/maven</url>
+      <url>https://www.lightstreamer.com/repo/maven</url>
     </repository>
   </repositories>
 </project>


### PR DESCRIPTION
This is a 1 letter change but needed in order to build.
Without it the downloaded jar file just contains:

<html>
<head><title>301 Moved Permanently</title></head>
<body bgcolor="white">
<center><h1>301 Moved Permanently</h1></center>
<hr><center>CloudFront</center>
</body>
</html>